### PR TITLE
[cleanup] Remove six dependency

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -5,9 +5,7 @@ import logging
 import base64
 import json
 import os
-
-import six
-from six.moves import urllib
+import urllib
 
 
 log = logging.getLogger(__name__)
@@ -55,8 +53,7 @@ class Check:
         Run the script *args* every *interval* (e.g. "10s") to peform health
         check
         """
-        if isinstance(args, six.string_types) \
-                or isinstance(args, six.binary_type):
+        if isinstance(args, (str, bytes)):
             warnings.warn(
                 "Check.script should take a list of args", DeprecationWarning)
             args = ["sh", "-c", args]
@@ -245,7 +242,7 @@ class CB:
         return cb
 
 
-class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
+class HTTPClient(metaclass=abc.ABCMeta):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
                  verify=True, cert=None):
         self.host = host
@@ -598,8 +595,7 @@ class Consul:
             """
             assert not key.startswith('/'), \
                 'keys should not start with a forward slash'
-            assert value is None or \
-                isinstance(value, (six.string_types, six.binary_type)), \
+            assert value is None or isinstance(value, (str, bytes)), \
                 "value should be None or a string / binary data"
 
             params = []

--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from six import b
 # noinspection PyUnresolvedReferences
 from treq.client import HTTPClient as TreqHTTPClient
 from twisted.internet import reactor
@@ -78,7 +77,7 @@ class HTTPClient(base.HTTPClient):
             # python2/3 compatibility
             data = kwargs.pop('data')
             kwargs['data'] = data.encode(encoding='utf-8') \
-                if hasattr(data, 'encode') else b(data)
+                if hasattr(data, 'encode') else bytes(data)
 
         try:
             response = yield self.client.request(method, url, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.0
-six>=1.4

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,6 +1,5 @@
 import base64
 import pytest
-import six
 import struct
 import sys
 
@@ -39,7 +38,7 @@ class TestAsyncioConsul:
             response = yield from c.kv.put('foo', 'bar')
             assert response is True
             index, data = yield from c.kv.get('foo')
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             c.close()
 
         loop.run_until_complete(main())
@@ -79,7 +78,7 @@ class TestAsyncioConsul:
             index, data = yield from c.kv.get('foo')
             assert data is None
             index, data = yield from c.kv.get('foo', index=index)
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             yield from fut
             c.close()
 
@@ -137,7 +136,7 @@ class TestAsyncioConsul:
             index, data = yield from c.kv.get('foo')
             assert data is None
             index, data = yield from c.kv.get('foo', index=index)
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             yield from fut
             c.close()
 

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -4,7 +4,6 @@ import struct
 import time
 
 import pytest
-import six
 
 import consul
 import consul.std
@@ -28,7 +27,7 @@ class TestConsul:
         assert data is None
         assert c.kv.put('foo', 'bar') is True
         index, data = c.kv.get('foo')
-        assert data['Value'] == six.b('bar')
+        assert data['Value'] == b'bar'
 
     def test_kv_wait(self, consul_port):
         c = consul.Consul(port=consul_port)
@@ -48,7 +47,7 @@ class TestConsul:
         # test unicode
         c.kv.put('foo', u'bar')
         index, data = c.kv.get('foo')
-        assert data['Value'] == six.b('bar')
+        assert data['Value'] == b'bar'
 
         # test empty-string comes back as `None`
         c.kv.put('foo', '')
@@ -72,7 +71,7 @@ class TestConsul:
         assert c.kv.put('foo', 'bar2', cas=data['ModifyIndex']-1) is False
         assert c.kv.put('foo', 'bar2', cas=data['ModifyIndex']) is True
         index, data = c.kv.get('foo')
-        assert data['Value'] == six.b('bar2')
+        assert data['Value'] == b'bar2'
 
     def test_kv_put_flags(self, consul_port):
         c = consul.Consul(port=consul_port)
@@ -100,7 +99,7 @@ class TestConsul:
         assert [x['Key'] for x in data] == [
             'foo/', 'foo/bar1', 'foo/bar2', 'foo/bar3']
         assert [x['Value'] for x in data] == [
-            None, six.b('1'), six.b('2'), six.b('3')]
+            None, b'1', b'2', b'3']
 
     def test_kv_delete(self, consul_port):
         c = consul.Consul(port=consul_port)
@@ -691,7 +690,7 @@ class TestConsul:
         # trying out the behavior
         assert c.kv.put('foo', '1', acquire=s) is True
         index, data = c.kv.get('foo')
-        assert data['Value'] == six.b('1')
+        assert data['Value'] == b'1'
 
         c.session.destroy(s)
         index, data = c.kv.get('foo')
@@ -757,13 +756,13 @@ class TestConsul:
         c.kv.put('foo', 'bar')
         c.kv.put('private/foo', 'bar')
 
-        assert c.kv.get('foo', token=token)[1]['Value'] == six.b('bar')
+        assert c.kv.get('foo', token=token)[1]['Value'] == b'bar'
         pytest.raises(
             consul.ACLPermissionDenied, c.kv.put, 'foo', 'bar2', token=token)
         pytest.raises(
             consul.ACLPermissionDenied, c.kv.delete, 'foo', token=token)
 
-        assert c.kv.get('private/foo')[1]['Value'] == six.b('bar')
+        assert c.kv.get('private/foo')[1]['Value'] == b'bar'
         pytest.raises(
             consul.ACLPermissionDenied,
             c.kv.get, 'private/foo', token=token)
@@ -831,13 +830,13 @@ class TestConsul:
         c.kv.put('private/foo', 'bar')
 
         c_limited = consul.Consul(port=acl_consul.port, token=token)
-        assert c_limited.kv.get('foo')[1]['Value'] == six.b('bar')
+        assert c_limited.kv.get('foo')[1]['Value'] == b'bar'
         pytest.raises(
             consul.ACLPermissionDenied, c_limited.kv.put, 'foo', 'bar2')
         pytest.raises(
             consul.ACLPermissionDenied, c_limited.kv.delete, 'foo')
 
-        assert c.kv.get('private/foo')[1]['Value'] == six.b('bar')
+        assert c.kv.get('private/foo')[1]['Value'] == b'bar'
         pytest.raises(
             consul.ACLPermissionDenied,
             c_limited.kv.get, 'private/foo')

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -3,7 +3,6 @@ import struct
 import time
 
 import pytest
-import six
 
 from tornado import ioloop
 from tornado import gen
@@ -39,7 +38,7 @@ class TestConsul:
             response = yield c.kv.put('foo', 'bar')
             assert response is True
             index, data = yield c.kv.get('foo')
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             loop.stop()
         loop.run_sync(main)
 
@@ -62,7 +61,7 @@ class TestConsul:
             index, data = yield c.kv.get('foo')
             assert data is None
             index, data = yield c.kv.get('foo', index=index)
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             loop.stop()
 
         @gen.coroutine
@@ -116,7 +115,7 @@ class TestConsul:
             index, data = yield c.kv.get('foo')
             assert data is None
             index, data = yield c.kv.get('foo', index=index)
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
             loop.stop()
 
         @gen.coroutine
@@ -142,7 +141,7 @@ class TestConsul:
             response = yield c.kv.put('foo', u'bar')
             assert response is True
             index, data = yield c.kv.get('foo')
-            assert data['Value'] == six.b('bar')
+            assert data['Value'] == b'bar'
 
             # test empty-string comes back as `None`
             response = yield c.kv.put('foo', '')

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -3,7 +3,6 @@ import struct
 
 import pytest_twisted
 
-import six
 from twisted.internet import defer, reactor
 
 import consul
@@ -33,7 +32,7 @@ class TestConsul:
         response = yield c.kv.put('foo', 'bar')
         assert response is True
         index, data = yield c.kv.get('foo')
-        assert data['Value'] == six.b('bar')
+        assert data['Value'] == b'bar'
 
     @pytest_twisted.inlineCallbacks
     def test_kv_binary(self, consul_port):
@@ -50,7 +49,7 @@ class TestConsul:
         index, data = yield c.kv.get('foo')
         assert data is None
         index, data = yield c.kv.get('foo', index=index)
-        assert data['Value'] == six.b('bar')
+        assert data['Value'] == b'bar'
 
     @pytest_twisted.inlineCallbacks
     def test_kv_put_flags(self, consul_port):
@@ -95,7 +94,7 @@ class TestConsul:
         index, data = yield c.kv.get('foo')
         assert data is None
         index, data = yield c.kv.get('foo', index=index)
-        assert data['Value'] == six.b('bar')
+        assert data['Value'] == b'bar'
 
     @pytest_twisted.inlineCallbacks
     def test_transaction(self, consul_port):


### PR DESCRIPTION
As python 2.7 is no longer supported, remove usage of six library that was used for retro compatibility.

It makes the code cleaner will allow to remove this dependency