### PR TITLE
Consul aiohttp features backport

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -53,7 +53,7 @@ class Consul(base.Consul):
 
     def connect(self, host, port, scheme, verify=True, cert=None):
         return HTTPClient(host, port, scheme, loop=self._loop,
-                          verify=verify, cert=None)
+                          verify=verify, cert=cert)
 
     def close(self):
         """Close all opened http connections"""


### PR DESCRIPTION
These features were historically used internally by monkey patching the lib in a not-so-pleasant way.
Proposing to align the open-source repository regarding these features on the aiohttp implementation (so that we can remove our specifics):
* correct support for client certificate
* connections limit override
* session timeout override