### PR TITLE
feature: allow multiple tags in service health query

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1517,7 +1517,8 @@ class Consul:
             Calling with *passing* set to True will filter results to only
             those nodes whose checks are currently passing.
 
-            Calling with *tag* will filter the results by tag.
+            Calling with *tag* will filter the results by tag, multiple tags 
+            using list possible.
 
             *dc* is the datacenter of the node and defaults to this agents
             datacenter.
@@ -1538,7 +1539,10 @@ class Consul:
             if passing:
                 params.append(('passing', '1'))
             if tag is not None:
-                params.append(('tag', tag))
+                if not isinstance(tag, list):
+                    tag = [tag]
+                for tag_item in tag:
+                    params.append(('tag', tag_item))                
             dc = dc or self.agent.dc
             if dc:
                 params.append(('dc', dc))


### PR DESCRIPTION
As of consul 1.3.0 api supports multiple tags.
Did not want to break backwards compatibility, so I did not change the param and made it possible to use string as in the past or a list for multiple tag params.