### PR TITLE
Add support for agent/service/:service_id API

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -722,6 +722,15 @@ class Consul:
             """
             return self.agent.http.get(CB.json(), '/v1/agent/services')
 
+        def service_definition(self, service_id):
+            """
+            Returns a service definition for a single instance that is registered
+            with the local agent.
+            """
+            return self.agent.http.get(
+                CB.json(),
+                '/v1/agent/service/%s' % service_id)
+
         def checks(self):
             """
             Returns all the checks that are registered with the local agent.


### PR DESCRIPTION
This was previously not introduced most probably because it breaks the general assumption that this wrapper will preserve the API namespacing, while here we have a collision between this endpoint (/v1/agent/service/:service_id) and the methods to register/deregister/add to maintenance (/v1/agent/service/register for example).

Solved this by changing the naming to "service_definition".