### PR TITLE
bugfix: rename internal connect method

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -64,7 +64,7 @@ class Consul(base.Consul):
         self.connections_timeout = connections_timeout
         super().__init__(*args, **kwargs)
 
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    def http_connect(self, host, port, scheme, verify=True, cert=None):
         return HTTPClient(host, port, scheme, loop=self._loop,
                           connections_limit=self.connections_limit,
                           connections_timeout=self.connections_timeout,

--- a/consul/base.py
+++ b/consul/base.py
@@ -323,7 +323,7 @@ class Consul:
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
-        self.http = self.connect(host, port, scheme, verify, cert)
+        self.http = self.http_connect(host, port, scheme, verify, cert)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
         self.scheme = scheme
         self.dc = dc

--- a/consul/std.py
+++ b/consul/std.py
@@ -40,5 +40,6 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    @staticmethod
+    def http_connect(host, port, scheme, verify=True, cert=None):
         return HTTPClient(host, port, scheme, verify, cert)

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -53,5 +53,6 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    @staticmethod
+    def http_connect(host, port, scheme, verify=True, cert=None):
         return HTTPClient(host, port, scheme, verify=verify, cert=cert)

--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -124,13 +124,13 @@ class HTTPClient(base.HTTPClient):
 
 class Consul(base.Consul):
     @staticmethod
-    def connect(host,
-                port,
-                scheme,
-                verify=True,
-                cert=None,
-                contextFactory=None,
-                **kwargs):
+    def http_connect(host,
+                     port,
+                     scheme,
+                     verify=True,
+                     cert=None,
+                     contextFactory=None,
+                     **kwargs):
         return HTTPClient(
             contextFactory, host, port, scheme, verify=verify, cert=cert,
             **kwargs)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -29,7 +29,7 @@ class HTTPClient:
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
+    def http_connect(self, host, port, scheme, verify=True, cert=None):
         return HTTPClient(host, port, scheme, verify=verify, cert=None)
 
 


### PR DESCRIPTION
To prevent any occurrence of conflicts between the Connect object that wraps Consul-Connect related APIs and the internal methods to setup the HTTP Client.

This is marked as breaking since each home-made implementation for a http client will have to rename its `connect` function into `http_connect`.