### PR TITLE
Add support for context-managers

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -277,6 +277,10 @@ class HTTPClient(metaclass=abc.ABCMeta):
     def post(self, callback, path, params=None, data=''):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def close(self):
+        raise NotImplementedError
+
 
 class Consul:
     def __init__(
@@ -344,6 +348,18 @@ class Consul:
         self.coordinate = Consul.Coordinate(self)
         self.operator = Consul.Operator(self)
         self.connect = Consul.Connect(self)
+
+    def __enter__(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.http.close()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.http.close()
 
     class Event:
         """

--- a/consul/std.py
+++ b/consul/std.py
@@ -38,6 +38,9 @@ class HTTPClient(base.HTTPClient):
             self.session.post(uri, data=data, verify=self.verify,
                               cert=self.cert)))
 
+    def close(self):
+        pass
+
 
 class Consul(base.Consul):
     def connect(self, host, port, scheme, verify=True, cert=None):

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -51,6 +51,9 @@ class HTTPClient(base.HTTPClient):
                                          validate_cert=self.verify)
         return self._request(callback, request)
 
+    def close(self):
+        self.client.close()
+
 
 class Consul(base.Consul):
     def connect(self, host, port, scheme, verify=True, cert=None):

--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -121,6 +121,10 @@ class HTTPClient(base.HTTPClient):
         response = yield self.request(callback, 'delete', uri, params=params)
         returnValue(response)
 
+    @inlineCallbacks
+    def close(self):
+        pass
+
 
 class Consul(base.Consul):
     @staticmethod


### PR DESCRIPTION
By implementing (a)enter/(a)exit internal methods, we bring the support for context-managers in the base.Consul object.

Context managers are quite convenient, especially for the aio implementation in which you may need a good control over objects lifecycle to prevent errors related to already-closed event loops:

This is done by forcing http implementations to define a close method and defining the (a)enter/(a)exit internal methods.
Most of the synchronous implementations will use a noop.

```
async with aio.Consul(...) as consul:
  svcs = consul.agent.services()
  # Implicit close of the HTTP client

```