### PR TITLE
connect: fix wrong endpoints callbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change log
 ==========
 
+1.2.2
+-----
+* bugfix: connect: fix wrong endpoints callbacks
+
 1.2.1
 -----
 * feature: Add support for context-managers

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 from consul.std import Consul
 

--- a/consul/base.py
+++ b/consul/base.py
@@ -1169,7 +1169,7 @@ class Consul:
                     params.append(('token', token))
 
                 return self.agent.http.put(
-                    CB.bool(),
+                    CB.json(),
                     '/v1/agent/connect/authorize',
                     params=params,
                     data=json.dumps(payload))
@@ -1190,7 +1190,7 @@ class Consul:
                         params.append(('token', token))
 
                     return self.agent.http.get(
-                        CB.bool(),
+                        CB.json(),
                         '/v1/agent/connect/ca/leaf/%s' % service,
                         params=params)
 
@@ -2617,7 +2617,7 @@ class Consul:
                     params.append(('token', token))
 
                 return self.agent.http.get(
-                    CB.bool(),
+                    CB.json(),
                     '/v1/connect/ca/roots',
                     params=params)
 
@@ -2628,6 +2628,6 @@ class Consul:
                     params.append(('token', token))
 
                 return self.agent.http.get(
-                    CB.bool(),
+                    CB.json(),
                     '/v1/connect/ca/configuration',
                     params=params)


### PR DESCRIPTION
In be07afd ("Introduce Consul Connect-related API wrappers")
multiple endpoint callbacks were associated to the wrong callback
type, resulting in boolean results where json payload is expected.