### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,19 @@
 Change log
 ==========
+1.4.0
+-----
+[Breaking] due to the re-implementation of the ACL endpoint and the drop of the support of OSX and consul 1.1.0.
+
+* feature: re-implement some basic ACL endpoint
+* feature: drop support of OSX and consul 1.1.0
+* feature: support multi-check service registration (through extra_checks parameter)
+* env: support python 3.12
+* tests: multi consul version test (1.13.8, 1.15.4, 1.16.1, 1.17.3)
+* tests: add test utils for cleaner API output expected assertion
+* code-style: use ruff linter and formatter
+* code-style: split files following the consul API logic
+* ci: speedup ci with uv/tox-uv
+
 1.3.0
 -----
 * feature: drop tornado and twisted support

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
-include README.rst
+include README.md
 include CHANGELOG.rst
 include LICENSE

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 from consul.base import ACLDisabled, ACLPermissionDenied, Check, ConsulException, NotFound, Timeout
 from consul.std import Consul

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,8 @@
-[tool.black]
-line-length = 120
-target-version = ['py39']
-include = '\.pyi?$'
-preview = true
-
-[tool.isort]
-line_length = 120
-case_sensitive = true
-profile = "black"
-src_paths = ["."]
-
 [tool.pytest.ini_options]
 addopts = "--cov=. --cov-context=test --durations=0 --durations-min=1.0"
 asyncio_mode = "auto"
 
 [tool.pylint]
-ignored-classes=["twisted.internet.reactor"]
 ignore-paths=["docs/"]
 
 [tool.pylint."messages control"]

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,7 @@ setup(
     py_modules=py_modules,
     install_requires=_read_reqs("requirements.txt"),
     extras_require={
-        "tornado": ["tornado"],
         "asyncio": ["aiohttp"],
-        "twisted": ["twisted", "treq"],
     },
     data_files=[(".", ["requirements.txt", "tests-requirements.txt"])],
     tests_require=_read_reqs("tests-requirements.txt"),


### PR DESCRIPTION
Change log
==========
1.4.0
-----
* feature: re-implement some basic ACL endpoint
* feature: drop support of OSX and consul 1.1.0
* feature: support multi-check service registration (through extra_checks parameter)
* env: support python 3.12
* tests: multi consul version test (1.13.8, 1.15.4, 1.16.1, 1.17.3)
* tests: add test utils for cleaner API output expected assertion
* code-style: use ruff linter and formatter
* code-style: split files following the consul API logic
* ci: speedup ci with uv/tox-uv